### PR TITLE
[ch2682]

### DIFF
--- a/api/orion/subscriptiondata.js
+++ b/api/orion/subscriptiondata.js
@@ -71,11 +71,12 @@ function getDataPage(sub, headers, page, cb) {
         getDataPage(sub, headers, page+1,cb);
 
       } else {
-        cb(null);
+        console.error('Couldn\'t retrieve subscription data on create:', response.body.errorCode);
+        cb(response.body.errorCode);
       }
 
     } else {
-      log.error('Request error: ' + error);
+      log.error('Request error: ', error);
       log.debug(response);
       cb(error);
     }

--- a/api/orion/subscriptions.js
+++ b/api/orion/subscriptions.js
@@ -157,7 +157,7 @@ function newOrionSubscription(sub, cb){
     }
     else{
       log.error(util.format('New subscription [%s] cannot be created',sub.id));
-      log.error('Request error: ' + JSON.stringify(response));
+      log.error('Request error: ' + JSON.stringify(response, null, 2));
       cb(error);
     }
   });
@@ -345,7 +345,7 @@ function createTable(sub,cb){
 function initialize(cb){
   tokenManager.createTokens(function(error,tokens){
     if (error) {
-      return log.error('Error, cannot create tokens for the provided credentials: '+error);
+      return log.error('Error, cannot create tokens for the provided credentials: ', error);
       if(cb) return cb(error);
     }
 

--- a/api/orion/tokenmanager.js
+++ b/api/orion/tokenmanager.js
@@ -53,12 +53,12 @@ function getAuthToken(sub, cb){
     };
 
     request(options, function (error, response, body) {
-      if (!error) {
+      if (!error && response.statusCode < 400) {
         var resp = JSON.parse(JSON.stringify(response));
         cb(null,resp.headers['x-subject-token']);
       }
       else{
-        cb(error,null);
+        cb(error || response.body,null);
       }
     });
   } else {

--- a/example_configs/config.cedus.madrid.traffic.yml
+++ b/example_configs/config.cedus.madrid.traffic.yml
@@ -38,18 +38,9 @@ subservices:
     service: madrid
     subservice: /analytics_kpis
 
-subscriptions:
-  - id: traffic_trafficflowobserved_lastdata
-    subservice_id: madrid_traffic
-    schemaname: madrid
-    fetchDataOnCreated: false
-    subsduration: P8M
-    substhrottling: PT0S
-    entityTypes:
-      - typeName: TrafficFlowObserved
-    mode: update
+_blocks:
+  - &traffic_trafficflowobserved_catalog
 
-    attributes:
       # Alternate key
       - name: code
         type: string
@@ -71,6 +62,14 @@ subscriptions:
         type: string
         cartodb: true
 
+      # Location
+      - name: location
+        namedb: position
+        type: geojson-point
+        cartodb: true
+
+  - &traffic_trafficflowobserved_variables
+
       # Flags
       - name: congested
         type: boolean
@@ -105,18 +104,27 @@ subscriptions:
         type: integer
         cartodb: true
 
-      # Location
-
-      - name: location
-        type: geojson-point
-        cartodb: true,
-        namedb: the_geom
-
       # Dates
       - name: dateObserved
         type: ISO8601
         cartodb: true
         namedb: TimeInstant
+
+subscriptions:
+
+  - id: traffic_trafficflowobserved_lastdata
+    subservice_id: madrid_traffic
+    schemaname: madrid
+    fetchDataOnCreated: false
+    subsduration: P8M
+    substhrottling: PT0S
+    entityTypes:
+      - typeName: TrafficFlowObserved
+    mode: update
+
+    attributes:
+      - *traffic_trafficflowobserved_catalog
+      - *traffic_trafficflowobserved_variables
 
     trigger_attributes:
       - dateObserved
@@ -132,58 +140,7 @@ subscriptions:
     mode: append
 
     attributes:
-      # Alternate key
-      - name: code
-        type: string
-        cartodb: true
-        constraint: true
-
-      - name: laneId
-        type: integer
-        cartodb: true
-        namedb: lane_id
-        constraint: true
-
-      # Flags
-      - name: congested
-        type: boolean
-        cartodb: true
-
-      - name: isHoliday
-        type: boolean
-        cartodb: true
-        namedb: is_holiday
-
-      # Indicators
-
-      - name: intensidadSat
-        type: integer
-        cartodb: true
-        namedb: intensity_sat
-
-      - name: intensity
-        type: integer
-        cartodb: true
-
-      - name: load
-        type: integer
-        cartodb: true
-
-      - name: nivelServicio
-        type: integer
-        cartodb: true
-        namedb: service_level
-
-      - name: occupancy
-        type: integer
-        cartodb: true
-
-      # Dates
-      - name: dateObserved
-        type: ISO8601
-        cartodb: true
-        namedb: TimeInstant
-        constraint: true
+      *traffic_trafficflowobserved_variables
 
     trigger_attributes:
       - dateObserved


### PR DESCRIPTION
~ Improved many error logs and error catch conditions here and there
~ Modified cedus traffic example config
+ config.yml->subscriptions[].attributes can now accept a list of lists
of attributes. Focused to encourage yaml block reusability. For an
example, please look at ``example_configs/config.cedus.madrid.traffic.yml``.